### PR TITLE
Dockerizar proyecto

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -7,12 +7,6 @@ WORKDIR /app
 # Copia el archivo JAR generado
 COPY target/protube-back-0.0.1-SNAPSHOT.jar app.jar
 
-# Establece las variables de entorno necesarias
-ENV ENV_PROTUBE_STORE_DIR=/home/jcatanzariti/protube/store
-ENV ENV_PROTUBE_DB=protube
-ENV ENV_PROTUBE_DB_USER=admin
-ENV ENV_PROTUBE_DB_PWD=1234
-
 # Expone el puerto del backend
 EXPOSE 8080
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,23 @@
+# Usa una imagen base de Amazon Corretto 21
+FROM amazoncorretto:21
+
+# Define el directorio de trabajo dentro del contenedor
+WORKDIR /app
+
+# Copia el archivo JAR generado
+COPY target/protube-back-0.0.1-SNAPSHOT.jar app.jar
+
+# Establece las variables de entorno necesarias
+ENV ENV_PROTUBE_STORE_DIR=/home/jcatanzariti/protube/store
+ENV ENV_PROTUBE_DB=protube
+ENV ENV_PROTUBE_DB_USER=admin
+ENV ENV_PROTUBE_DB_PWD=1234
+
+# Expone el puerto del backend
+EXPOSE 8080
+
+# Mount volume for the store directory
+VOLUME /store
+
+# Comando para iniciar la aplicación
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -18,7 +18,7 @@ spring.thymeleaf.prefix=classpath:/templates/
 #---
 spring.config.activate.on-profile=prod
 pro_tube.load_initial_data=false
-spring.datasource.url=jdbc:postgresql://localhost:5432/${ENV_PROTUBE_DB}
+spring.datasource.url=jdbc:postgresql://localhost:5433/${ENV_PROTUBE_DB}
 spring.datasource.username=${ENV_PROTUBE_DB_USER}
 spring.datasource.password=${ENV_PROTUBE_DB_PWD}
 spring.jpa.show-sql=true

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -18,7 +18,8 @@ spring.thymeleaf.prefix=classpath:/templates/
 #---
 spring.config.activate.on-profile=prod
 pro_tube.load_initial_data=false
-spring.datasource.url=jdbc:postgresql://localhost:5433/${ENV_PROTUBE_DB}
+spring.datasource.url=jdbc:postgresql://localhost:5432/${ENV_PROTUBE_DB}
+# Cambiar puerto a 5433 para docker
 spring.datasource.username=${ENV_PROTUBE_DB_USER}
 spring.datasource.password=${ENV_PROTUBE_DB_PWD}
 spring.jpa.show-sql=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.8'
+
+services:
+  db:
+    image: postgres:latest
+    container_name: postgres-db
+    environment:
+      POSTGRES_USER: ${ENV_PROTUBE_DB_USER}
+      POSTGRES_PASSWORD: ${ENV_PROTUBE_DB_PWD}
+      POSTGRES_DB: ${ENV_PROTUBE_DB}
+    ports:
+      - "5433:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+
+volumes:
+  postgres-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,8 +29,7 @@ services:
     ports:
       - "8080:8080"
     volumes:
-      - /home/jcatanzariti/protube/store:/store
-      # cambiar jcatanzariti por el nombre de usuario de tu maquina ubuntu
+      - ${ENV_PROTUBE_STORE_DIR}:/store
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,4 @@
-version: '3.8'
-
+version: "3.9"
 services:
   db:
     image: postgres:latest
@@ -12,6 +11,28 @@ services:
       - "5433:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
+
+  app:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: protube-app
+    environment:
+      ENV_PROTUBE_STORE_DIR: /store
+      ENV_PROTUBE_DB: ${ENV_PROTUBE_DB}
+      ENV_PROTUBE_DB_USER: ${ENV_PROTUBE_DB_USER}
+      ENV_PROTUBE_DB_PWD: ${ENV_PROTUBE_DB_PWD}
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/${ENV_PROTUBE_DB}
+      SPRING_DATASOURCE_USERNAME: ${ENV_PROTUBE_DB_USER}
+      SPRING_DATASOURCE_PASSWORD: ${ENV_PROTUBE_DB_PWD}
+      SPRING_PROFILES_ACTIVE: docker
+    ports:
+      - "8080:8080"
+    volumes:
+      - /home/jcatanzariti/protube/store:/store
+      # cambiar jcatanzariti por el nombre de usuario de tu maquina ubuntu
+    depends_on:
+      - db
 
 volumes:
   postgres-data:


### PR DESCRIPTION
AÑADIR A README:
- En aplication.properties la linea "spring.datasource.url=jdbc:postgresql://localhost:5432/${ENV_PROTUBE_DB}" es la dirección de la DB de prod para que al ejecutar "mvn spring-boot:run -P prod" funcione con normalidad, ya que sino falla la conexion con la DB. En cambio, si de la linea esta se cambia el puerto a "5433" la conexion sera con la DB de docker, la cual se conecta el  proyecto dockerizado. (He querido dejar separado lo que es el prod de todo el tema relacionado con el docker).
- Para crear los contenedores hay que ejecutar en la raiz del proyecto "docker-compose up --build".
- Para ver los contenedores en Docker Desktop hay que activar lo siguiente en configuracion:
![image](https://github.com/user-attachments/assets/0b394fda-740f-45d5-9b3e-daa90d32b83d)
